### PR TITLE
[bugfix] 解决github键传不同值显示与链接问题

### DIFF
--- a/src/Info/index.tsx
+++ b/src/Info/index.tsx
@@ -12,10 +12,10 @@ function Info() {
           {info.github ? (
             <a
               className={styles.github}
-              href={`https://github.com/${info.github}`} target='_blank'
+              href={info.github.startsWith('https://github.com/') ? info.github : `https://github.com/${info.github}.com`}  target='_blank'
             >
               <GithubFilled />
-              <span className={styles.username}>{info.github}</span>
+              <span className={styles.username}>{info.github.startsWith('https://github.com/') ? info.github : `https://github.com/${info.github}.com`}</span>
             </a>
           ) : null}
         </div>


### PR DESCRIPTION
- 当传入“名称”时，显示完全地址，链接完全地址
- 当传入“完全地址”时，显示完全地址，链接完全地址